### PR TITLE
Add another good use case for using `load`

### DIFF
--- a/understaning-require-in-ruby.md
+++ b/understaning-require-in-ruby.md
@@ -89,7 +89,7 @@ it was with `require`.
 
 All in all, I would say that `load` has a fairly small amount of usefulness.
 Probably it's main use case is re-running a file from a Ruby REPL (like pry or
-irb) after making some edits.
+irb) after making some edits.  It's also very helpful when you need to load ruby files that do not have a .rb extension since `require` will automatically look for files ending in .rb.  This situation can occur when tryig to load ruby script files or executables which tend not to have an extension.
 
 Understanding `require_relative`
 --------------------------------


### PR DESCRIPTION
I recently ran into a situation where I was trying to require a template of a script file (which didn't end in .rb), into another script file.  I already had the template, so there was no point in duplicating the code.  I initially tried to require it and wasted a good 45min trying to figure out why it wouldn't require.   `load` saved the day because it didn't try to tack on a `.rb` extension to the file.  Your article, helped me understand some of the issues involved and I thought another example of where `load` is essential might be helpful to others.
